### PR TITLE
Add `bundle update` step to README.md installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ enabled. Then:
 ```sh
 cd [canvas-rails-root]
 git clone [analytics-repo-url] gems/plugins/analytics
+bundle update
 rake db:migrate
 rake canvas:compile_assets
 ```


### PR DESCRIPTION
The bundle must be updated after the analytics package has been added. Not doing so will result in errors during the database migration step.